### PR TITLE
Switch to NodeJS v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,5 @@ description: >
 inputs: {}
 outputs: {}
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Currently we see this error:

```
The following actions uses node12 which is deprecated and will be forced to run on node16: giantswarm/floating-tags-action@80ab97ac423893e85897266c75290b93b7946617
```