### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,0 @@
-# Teams:
-
-# Individuals:
-* @kopiczko


### PR DESCRIPTION
I'm deleting the codeowners file which shows @kopiczko as the repo owner, to allow for the next "Align files" PR to assign the repo to team rocket, who own this according to

https://github.com/giantswarm/github/blob/main/repositories/team-rocket.yaml#L113-L119